### PR TITLE
Add in an "Intro Enable" checkbox.

### DIFF
--- a/src/backend/ui.c
+++ b/src/backend/ui.c
@@ -18,6 +18,7 @@ void UI_RunFrame(struct nk_context* ctx) {
   // System settings
   static int32_t emulationSpeed = 100;
   static nk_bool emulationPaused = false;
+  static nk_bool introShown = true;
 
   // Popup window settings
   static bool showHelp = false;
@@ -58,7 +59,7 @@ void UI_RunFrame(struct nk_context* ctx) {
     }
 
     // Emulation
-    if (nk_menu_begin_label(ctx, "System", NK_TEXT_CENTERED, nk_vec2(175, 220))) {
+    if (nk_menu_begin_label(ctx, "System", NK_TEXT_CENTERED, nk_vec2(175, 240))) {
       nk_layout_row_dynamic(ctx, 25, 1);
       if (nk_menu_item_label(ctx, "Toggle FullScreen", NK_TEXT_LEFT)) {
         sapp_toggle_fullscreen();
@@ -67,6 +68,10 @@ void UI_RunFrame(struct nk_context* ctx) {
       emulationPaused = VSmile_GetPaused();
       nk_checkbox_label(ctx, "Paused",  &emulationPaused);
       VSmile_SetPause(emulationPaused);
+
+      introShown = VSmile_GetIntroEnable();
+      nk_checkbox_label(ctx, "Intro Enabled", &introShown);
+      VSmile_SetIntroEnable(introShown);
 
       if (nk_menu_item_label(ctx, "Step", NK_TEXT_LEFT)) {
         VSmile_Step();

--- a/src/core/vsmile.c
+++ b/src/core/vsmile.c
@@ -1,5 +1,7 @@
 #include "vsmile.h"
 
+bool VSmile_IntroEnabled = true;
+
 static VSmile_t this;
 
 bool VSmile_Init() {
@@ -69,7 +71,12 @@ void VSmile_SetRegion(uint8_t region) {
 }
 
 void VSmile_SetIntroEnable(bool shouldShowIntro) {
+  VSmile_IntroEnabled = shouldShowIntro;
   GPIO_SetIntroEnable(shouldShowIntro);
+}
+
+bool VSmile_GetIntroEnable() {
+  return VSmile_IntroEnabled;
 }
 
 

--- a/src/core/vsmile.c
+++ b/src/core/vsmile.c
@@ -1,7 +1,5 @@
 #include "vsmile.h"
 
-bool VSmile_IntroEnabled = true;
-
 static VSmile_t this;
 
 bool VSmile_Init() {
@@ -71,12 +69,12 @@ void VSmile_SetRegion(uint8_t region) {
 }
 
 void VSmile_SetIntroEnable(bool shouldShowIntro) {
-  VSmile_IntroEnabled = shouldShowIntro;
+  this.introEnabled = shouldShowIntro;
   GPIO_SetIntroEnable(shouldShowIntro);
 }
 
 bool VSmile_GetIntroEnable() {
-  return VSmile_IntroEnabled;
+  return this.introEnabled;
 }
 
 

--- a/src/core/vsmile.c
+++ b/src/core/vsmile.c
@@ -10,6 +10,7 @@ bool VSmile_Init() {
   if (!Controller_Init()) return false;
 
   this.clockScale = 1.0f;
+  this.introEnabled = true;
 
   return true;
 }

--- a/src/core/vsmile.h
+++ b/src/core/vsmile.h
@@ -29,6 +29,7 @@ void VSmile_LoadROM(const char* path);
 void VSmile_LoadSysRom(const char* path);
 void VSmile_SetRegion(uint8_t region);
 void VSmile_SetIntroEnable(bool shouldShowIntro);
+bool VSmile_GetIntroEnable();
 
 bool VSmile_GetPaused();
 void VSmile_SetPause(bool isPaused);

--- a/src/core/vsmile.h
+++ b/src/core/vsmile.h
@@ -16,8 +16,7 @@
 typedef struct VSmile_t {
   int32_t cyclesLeft;
   float clockScale;
-  bool paused, step;
-  bool introEnabled = true;
+  bool paused, step, introEnabled;
 } VSmile_t;
 
 bool VSmile_Init();

--- a/src/core/vsmile.h
+++ b/src/core/vsmile.h
@@ -17,6 +17,7 @@ typedef struct VSmile_t {
   int32_t cyclesLeft;
   float clockScale;
   bool paused, step;
+  bool introEnabled = true;
 } VSmile_t;
 
 bool VSmile_Init();


### PR DESCRIPTION
This should allow you to at least skip the V.Tech logo within the V.Smile BIOS.